### PR TITLE
Update bindgen version in tutorial.

### DIFF
--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -5,5 +5,5 @@ Declare a build-time dependency on `bindgen` by adding it to the
 
 ```toml
 [build-dependencies]
-bindgen = "0.26.3"
+bindgen = "0.42.2"
 ```


### PR DESCRIPTION
The bindgen version in the tutorial _very_ old. `0.42.2` is a little better.